### PR TITLE
remove credentials

### DIFF
--- a/src/provider.js
+++ b/src/provider.js
@@ -72,8 +72,8 @@ const handleAuthenticateGetRequest = (req, res) => {
 
 const handleRevokeRequest = (req, res) => {
   validateRevokeBody(req)
-  .then(gcs.deleteFromGCS)
   .then(db.deleteFromDB)
+  .then(() => gcs.deleteFromGCS(req))
   .then(()=>{res.json({key: req.body.key, revoked: true})})
   .catch(error=>{
     handleError(res, error, "Error when revoking");


### PR DESCRIPTION
## Description
Removes Redis key before deleting GCS

## Motivation and Context
If GCS file does not exist for some reason, but Redis key does, the call fails and the Redis key removal never happens, and the account gets stuck without being able to remove / add twitter credentials, and this has resulted in support tickets.

If we remove the Redis key first we ensure it always gets cleared and prevent the account from being stuck.

## How Has This Been Tested?
I manually revoked and authenticated an account in apps staging.

I also tested with staging server using the E2E tests that perform key removal:

```
Token: a913-a9-07d-415-5e759ea85

OAuth.io Result: {"oauth_token":"1031892969396174849-89FWDoDRffj5Q4Yg3eqdUpzy7d7cZ6","oauth_token_secret":"MZfKiyl3UPBnUCYp60g11qMkOZuQh1W8ZgQypGN64wk2c","code":"_7UbTMpkESNhMYpzxd2cajpW9XE","provider":"twitter"}

Key: b9143310-d459-4f64-b187-b2e8178d6b9d:twitter:19

Authentication result: {"authenticated":["19"]}

Revoke result: {"key":"b9143310-d459-4f64-b187-b2e8178d6b9d:twitter:19","revoked":true}

Status result: {"authenticated":[]}
```

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
     - To be released before Friday, or on Monday.
     - Simple rollback is enough to revert.
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No need to notifiy support. No need to update documentation.
