### PR TITLE
Feature/clear credentials function

### DIFF
--- a/test/unit/db.test.js
+++ b/test/unit/db.test.js
@@ -1,0 +1,116 @@
+/* eslint-env mocha */
+
+const assert = require("assert");
+const simple = require("simple-mock");
+const db = require("../../src/db");
+const redis = require("redis-promise");
+
+describe("db", ()=>{
+
+  beforeEach(()=>{
+    simple.mock(redis, "deleteKey").resolveWith();
+    simple.mock(redis, "setRemove").resolveWith();
+  });
+
+  afterEach(()=>{
+    simple.restore();
+  });
+
+  it("gets the credentials", ()=>{
+    simple.mock(redis, "getSet").resolveWith(["10"]);
+
+    return db.checkKey({ body: {
+      companyId: "xxxyy",
+      provider: "twitter"
+    }}).then(keys => {
+      assert.deepEqual(keys, ["10"]);
+
+      assert.equal(redis.getSet.callCount, 1);
+      assert.equal(redis.getSet.lastCall.args[0], "xxxyy:twitter");
+    });
+  });
+
+  it("deletes a credential from database", ()=>{
+    return db.deleteFromDB({ body: {
+      key: "xxxyy:twitter:30"
+    }}).then(() => {
+      assert.equal(redis.deleteKey.callCount, 1);
+      assert.equal(redis.deleteKey.lastCall.args[0], "xxxyy:twitter:30");
+
+      assert.equal(redis.setRemove.callCount, 1);
+      assert.equal(redis.setRemove.lastCall.args[0], "xxxyy:twitter");
+      assert.deepEqual(redis.setRemove.lastCall.args[1], ["30"]);
+    });
+  });
+
+  it("clears the credentials", ()=>{
+
+    function isValidKey(key) {
+      return ["10", "11", "12"].includes(key);
+    }
+
+    function isValidFullKey(key) {
+      const parts = key.split(":");
+
+      return parts[0] === "xxxyy" && parts[1] === "twitter" && isValidKey(parts[2]);
+    }
+
+    simple.mock(redis, "getSet").resolveWith(["10", "11", "12"]);
+
+    return db.clearCredentials({ body: {
+      companyId: "xxxyy",
+      provider: "twitter"
+    }}).then(() => {
+      assert.equal(redis.getSet.callCount, 1);
+      assert.equal(redis.getSet.lastCall.args[0], "xxxyy:twitter");
+
+      assert.equal(redis.deleteKey.callCount, 3);
+      console.log(redis.deleteKey.calls[0].args[0]);
+      console.log(redis.deleteKey.calls[1].args[0]);
+      console.log(redis.deleteKey.calls[2].args[0]);
+      console.log("--------------------------------------");
+      assert(isValidFullKey(redis.deleteKey.calls[0].args[0]));
+      assert(isValidFullKey(redis.deleteKey.calls[1].args[0]));
+      assert(isValidFullKey(redis.deleteKey.calls[2].args[0]));
+
+      assert.equal(redis.setRemove.callCount, 3);
+      assert.equal(redis.setRemove.calls[0].args[0], "xxxyy:twitter");
+      assert(isValidKey(redis.setRemove.calls[0].args[1][0]));
+      assert.equal(redis.setRemove.calls[1].args[0], "xxxyy:twitter");
+      assert(isValidKey(redis.setRemove.calls[0].args[1][0]));
+      assert.equal(redis.setRemove.calls[2].args[0], "xxxyy:twitter");
+      assert(isValidKey(redis.setRemove.calls[0].args[1][0]));
+    });
+  });
+
+  it("doesn't clear if there are not credentials", ()=>{
+    simple.mock(redis, "getSet").resolveWith(null);
+
+    return db.clearCredentials({ body: {
+      companyId: "xxxyy",
+      provider: "twitter"
+    }}).then(() => {
+      assert.equal(redis.getSet.callCount, 1);
+      assert.equal(redis.getSet.lastCall.args[0], "xxxyy:twitter");
+
+      assert.equal(redis.deleteKey.callCount, 0);
+      assert.equal(redis.setRemove.callCount, 0);
+    });
+  });
+
+  it("doesn't clear if there are not errors retrieving the keys", ()=>{
+    simple.mock(redis, "getSet").rejectWith(null);
+
+    return db.clearCredentials({ body: {
+      companyId: "xxxyy",
+      provider: "twitter"
+    }}).then(() => {
+      assert.equal(redis.getSet.callCount, 1);
+      assert.equal(redis.getSet.lastCall.args[0], "xxxyy:twitter");
+
+      assert.equal(redis.deleteKey.callCount, 0);
+      assert.equal(redis.setRemove.callCount, 0);
+    });
+  });
+
+});

--- a/test/unit/db.test.js
+++ b/test/unit/db.test.js
@@ -98,7 +98,7 @@ describe("db", ()=>{
     });
   });
 
-  it("doesn't clear if there are not errors retrieving the keys", ()=>{
+  it("doesn't clear if there are errors retrieving the keys", ()=>{
     simple.mock(redis, "getSet").rejectWith(null);
 
     return db.clearCredentials({ body: {

--- a/test/unit/db.test.js
+++ b/test/unit/db.test.js
@@ -1,4 +1,5 @@
 /* eslint-env mocha */
+/* eslint-disable max-statements, no-magic-numbers */
 
 const assert = require("assert");
 const simple = require("simple-mock");

--- a/test/unit/db.test.js
+++ b/test/unit/db.test.js
@@ -66,10 +66,6 @@ describe("db", ()=>{
       assert.equal(redis.getSet.lastCall.args[0], "xxxyy:twitter");
 
       assert.equal(redis.deleteKey.callCount, 3);
-      console.log(redis.deleteKey.calls[0].args[0]);
-      console.log(redis.deleteKey.calls[1].args[0]);
-      console.log(redis.deleteKey.calls[2].args[0]);
-      console.log("--------------------------------------");
       assert(isValidFullKey(redis.deleteKey.calls[0].args[0]));
       assert(isValidFullKey(redis.deleteKey.calls[1].args[0]));
       assert(isValidFullKey(redis.deleteKey.calls[2].args[0]));


### PR DESCRIPTION
## Description
Create function that clears credentials for a company and service ( e.g. 'twitter' ) on Redis

## Motivation and Context
Part of execution strategy.

This PR just creates the function and defines unit tests for it, it's still not being called from any endpoint. Refactoring to deleteFromDB existing function was done in order to reuse its functionality on the new function.

## How Has This Been Tested?
I tested on staging that old twitter widget functionality for authentication / removal is not broken ( E2E tests and manually on apps-stage-9 ).

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
     - To be released on Monday
     - Manual and automated tests created
     - Simple rollback is enough to revert changes.
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No need to notify support. No need to update documentation.
