### PR TITLE
Feature/clear credentials before adding

### DIFF
--- a/src/provider.js
+++ b/src/provider.js
@@ -57,7 +57,10 @@ const handleAuthenticatePostRequest = (req, res) => {
   validateAuthenticateBody(req)
   .then(authenticator.authenticate)
   .then(authenticator.handleAuthentication)
-  .then(db.saveToDB)
+  .then(auth=>{
+    return db.clearCredentials(auth)
+    .then(() => db.saveToDB(auth));
+  })
   .then(gcs.saveToGCS)
   .then((auth)=>{res.json({key: auth.key, authenticated: true})})
   .catch(error=>{

--- a/test/unit/provider.test.js
+++ b/test/unit/provider.test.js
@@ -140,7 +140,7 @@ describe("Provider", ()=>{
     it("clears credentials before adding new", ()=>{
       provider.handleAuthenticatePostRequest(req, res);
 
-      return resPromise.then(body=>{
+      return resPromise.then(()=>{
         assert.equal(redis.getSet.callCount, 1);
         assert.equal(redis.getSet.lastCall.args[0], "xxxxx:twitter");
 
@@ -158,7 +158,7 @@ describe("Provider", ()=>{
 
       provider.handleAuthenticatePostRequest(req, res);
 
-      return resPromise.then(body=>{
+      return resPromise.then(()=>{
         assert.equal(redis.getSet.callCount, 1);
         assert.equal(redis.getSet.lastCall.args[0], "xxxxx:twitter");
 


### PR DESCRIPTION
## Description
Clears previous oauth credentials before adding a new one

## Motivation and Context
Part of the execution strategy.

This is needed to prevent issues with Twitter component settings ( and also Twitter widget ) when a user revokes permissions from Twitter page.

In Twitter component settings, a revoked credential will cause the Twitter authentication button to appear. But if in this case a new credential is added on the current oauth token provider implementation, a new credential will be added on top of the previous ( revoked ) one, as there is no explicit way in the new component to revoke credentials, and this could lead to issues.

So the safest way to solve this is to ensure that the previous credential is deleted before adding a new one, and in this case only the latest credential is kept in Redis. 

## How Has This Been Tested?
E2E tests on staging were tested manually. New unit tests were created to verify this behavior.

I also tested adding and removing credentials from twitter widget, and adding credentials on our new Twitter credential settings on top of other ones:

https://apps-stage-9.risevision.com/templates/edit/ba52cc8e-88da-44b1-a882-268070649747/?cid=121ae986-1b89-40c8-b10b-a64c60fb9e03

To replicate open a Twitter example template, and authenticate, this will create a new credential file in GCS.

Open the GCS console and note the last modified date for the twitter.json credential file:
![Screenshot from 2020-02-24 13-54-32](https://user-images.githubusercontent.com/33162690/75187170-2380f000-570f-11ea-855a-f2ab9db02c8f.png)

Then close the template presentation, open it again, and do twitter authentication again ( currently credentials validation is not implemented, so we can authenticate on top of previous credentials ).

Once done, refresh the file in the GCS console, and verify that the twitter.json file has been updated.

Then manually request an status for that company on the staging oauth-token-provider service, and verify that there is a single key returned:

```
curl -X POST  -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" -d '{ "companyId": "121ae986-1b89-40c8-b10b-a64c60fb9e03", "provider": "twitter" }' http://services-stage.risevision.com/oauthtokenprovider/status
```

In this case, this returned:

```
{"authenticated":["27"]}
```

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
    - To be released before Friday
    - Manual and automated tests created.
    - Simple rollback is enough to revert these changes.
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No need to notify support; no need to update documentation.
